### PR TITLE
Rename deprecated GA and Disqus config settings

### DIFF
--- a/layouts/partials/comments.html
+++ b/layouts/partials/comments.html
@@ -1,4 +1,4 @@
-{{ if .Site.DisqusShortname }}
+{{ if .Site.Config.Services.Disqus.Shortname }}
     {{ partial "disqus.html" . }}
 {{ end }}
 

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -75,7 +75,7 @@
 <meta property="article:tag" content="">
 <meta property="article:publisher" content="https://www.facebook.com/XXX"> -->
 
-{{ if and (.Site.GoogleAnalytics) (hugo.IsProduction) }}
+{{ if and (.Site.Config.Services.GoogleAnalytics.ID) (hugo.IsProduction) }}
     {{ template "_internal/google_analytics.html" . }}
 {{ end }}
 


### PR DESCRIPTION
Deprecated in Hugo 0.120.0, removed in Hugo 0.137.0